### PR TITLE
Fix: English profile is missing (english language is available)

### DIFF
--- a/src/assets/manifest.local.json
+++ b/src/assets/manifest.local.json
@@ -1,0 +1,17 @@
+{
+  "version": 1,
+  "profiles": {
+    "en": {
+      "default": {
+        "url": "https://res.cloudinary.com/dezti7ski/raw/upload/v1761340716/profile1_en_backup.zip",
+        "name": "Teenager Profile 1 "
+      }
+    },
+    "fi": {
+      "default": {
+        "url": "https://res.cloudinary.com/dezti7ski/raw/upload/v1761341888/profile1_fi_backup.zip",
+        "name": "Teenager Profile 1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR introduces a robust **local manifest fallback** mechanism within the `ProfileLoader` component. This change addresses an issue where profile loading would completely fail if the remote manifest fetch failed (due to network issues, invalid JSON, or server errors, such as the current unavailability of the 'en' profile ZIP).

### Detailed Changes

1.  Modified `useEffect` hook in `ProfileLoader.tsx` to handle failures in `fetch(m.url, { method: 'HEAD' })` at two points:
    * **Request Response Failure:** Catches errors from the response of the initial `fetch`.
    * **Network Request Failure:** Catches errors from a network failure.
2.  In both error scenarios, the component now **falls back to using the `localManifest`** file residing in the application.
3.  The `onError` prop is *not* triggered when the local manifest is successfully loaded, as this is considered a successful mitigation.

### Context for UEF GenAI Lab

This ensures the **Profiling Game** remains functional and allows for continued development and testing, particularly for initial setup and languages (like 'en') where the live assets might not yet be fully deployed on the store server. This contributes to the overall stability and reliability of the project, which is critical for ongoing research and data collection.

**New Doctoral Researcher Contribution:** This is my first contribution to the UEF GenAI Projects. Feedback on PR style and adherence to project standards is welcome!